### PR TITLE
VS Code options should not initialize envDirName by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -466,7 +466,6 @@
         "httpyac.envDirName": {
           "type": "string",
           "scope": "resource",
-          "default": "env",
           "description": "relative or absolute path to folder with env files"
         },
         "httpyac.useRegionScopedVariables": {


### PR DESCRIPTION
Related to https://github.com/AnWeber/httpyac/issues/103

If `envDirName` is not defined, code within httpyac will use the default value of `env` automatically. Defining it by default in VS Code disables the possibility of using `envDirName` in `.httpyac.json` (or similar configuration files not tied to VS Code).