### PR TITLE
Use undefined for envDirName if VS Code envDirName config is falsy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -137,7 +137,7 @@ export async function getEnvironmentConfig(fileName: httpyac.PathLike): Promise<
     requestBodyInjectVariablesExtensions: config.requestBodyInjectVariablesExtensions,
     proxy: httpyac.utils.isString(httpOptions.proxy) ? httpOptions.proxy : undefined,
     defaultHeaders: config.requestDefaultHeaders,
-    envDirName: config.envDirName,
+    envDirName: config.envDirName || undefined,
     useRegionScopedVariables: config.useRegionScopedVariables,
   };
 


### PR DESCRIPTION
Unfortunately I noticed too late that the change in #84 was not sufficient to fix https://github.com/AnWeber/httpyac/issues/103. 

Since envDirName is defined as a VS Code config value of type `string`, the API will return an empty string as the default value.

Because of this the lodash.merge that is run in `getEnviromentConfig` will apply that value from VS Code. 

Proposed fix: Coalesce a falsy value for `envDirName` to `undefined` and thus use the following property of the `lodash.merge` function: (ref. https://lodash.com/docs#merge)

> Source properties that resolve to `undefined` are skipped if a destination value exists.