### PR TITLE
Clear exported variables when clearing response history

### DIFF
--- a/src/provider/historyController.ts
+++ b/src/provider/historyController.ts
@@ -82,6 +82,7 @@ export class HistoryController extends DisposeProvider implements vscode.TreeDat
       const httpFile = await this.documentStore.getHttpFile(document);
       if (httpFile) {
         for (const httpRegion of httpFile.httpRegions) {
+          httpRegion.variablesPerEnv = {};
           delete httpRegion.response;
         }
       }


### PR DESCRIPTION
When selecting the Clear Response history command in VS Code, the command should also clear cached exported variables for the region, so that other requests that `@ref` a region in the file will reevaulate the `@ref`.

The problem is: The response property on the region is not evaluated during `@ref`. During execution of a region, the exported variables (including the parsed body of a response) are assigned to the `variablesPerEnv` property of the region. And during a `@ref` action, the `variables` of the context is assigned to using the `variablesPerEnv` of the referenced region.