### PR TITLE
fix: correctly show tests with space or nonasci chars in filename

### DIFF
--- a/src/provider/test/testItemResolver.ts
+++ b/src/provider/test/testItemResolver.ts
@@ -146,7 +146,7 @@ export class TestItemResolver extends DisposeProvider {
 
   private createFileTestItem(file: vscode.Uri, httpFile?: httpyac.HttpFile) {
     const parent = this.getParentTestItem(file);
-    const testItem = this.createTestItem(TestItemKind.file, basename(file.toString()), file);
+    const testItem = this.createTestItem(TestItemKind.file, basename(file.toString(true)), file);
     testItem.canResolveChildren = true;
     parent.children.add(testItem);
 
@@ -166,7 +166,7 @@ export class TestItemResolver extends DisposeProvider {
     this.testController.items.add(workspaceTestItem);
 
     const folderUri = vscode.Uri.joinPath(file, '..');
-    const folder = folderUri.toString().replace(workspaceRoot.uri.toString(), '');
+    const folder = folderUri.toString(true).replace(workspaceRoot.uri.toString(true), '');
     if (folder) {
       const folderTestItem = this.createTestItem(TestItemKind.folder, folder, folderUri);
       workspaceTestItem.children.add(folderTestItem);


### PR DESCRIPTION
before:
![obrazek](https://user-images.githubusercontent.com/10436347/207038685-5ee3cbd7-f80f-4e39-8617-d0b9e2160cc9.png)
after:
![obrazek](https://user-images.githubusercontent.com/10436347/207038889-6cf91847-1fa2-4a0f-8f7b-f845edf727fd.png)
