### PR TITLE
Added navigation for request Body files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,10 @@ export function activate(context: vscode.ExtensionContext): HttpYacExtensionApi 
       new provider.VariablesHoverProvider(documentStore, storeController.environmentChanged),
       new provider.VariablesTreeDataProvider(documentStore, storeController.environmentChanged),
       new provider.TestController(documentStore, responseStore, storeController),
-      vscode.languages.registerDefinitionProvider(config.allHttpDocumentSelector, new provider.HttpDefinitionProvider(documentStore)),
+      vscode.languages.registerDefinitionProvider(
+        config.allHttpDocumentSelector,
+        new provider.HttpDefinitionProvider(documentStore)
+      ),
       vscode.languages.registerDocumentSymbolProvider(
         config.allHttpDocumentSelector,
         new provider.HttpDocumentSymbolProvider(documentStore)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ export function activate(context: vscode.ExtensionContext): HttpYacExtensionApi 
       new provider.VariablesHoverProvider(documentStore, storeController.environmentChanged),
       new provider.VariablesTreeDataProvider(documentStore, storeController.environmentChanged),
       new provider.TestController(documentStore, responseStore, storeController),
+      vscode.languages.registerDefinitionProvider(config.allHttpDocumentSelector, new provider.HttpDefinitionProvider(documentStore)),
       vscode.languages.registerDocumentSymbolProvider(
         config.allHttpDocumentSelector,
         new provider.HttpDocumentSymbolProvider(documentStore)

--- a/src/provider/httpDefinitionProvider.ts
+++ b/src/provider/httpDefinitionProvider.ts
@@ -1,0 +1,102 @@
+
+import * as vscode from 'vscode'
+import { DocumentStore } from '../documentStore';
+
+import * as fs   from 'fs';
+import * as path from 'path';
+
+// thanks to https://github.com/abierbaum/vscode-file-peek
+
+export class HttpDefinitionProvider implements vscode.DefinitionProvider {
+
+  protected fileSearchExtensions: string[] = ['json'];
+
+  constructor(readonly documentStore: DocumentStore){
+    
+  }
+
+  provideDefinition(document: vscode.TextDocument, 
+                    position: vscode.Position, 
+                    token: vscode.CancellationToken): vscode.ProviderResult<vscode.Definition | vscode.LocationLink[]> {
+    let working_dir = path.dirname(document.fileName);
+    let word        = document.getText(document.getWordRangeAtPosition(position));
+    let line        = document.lineAt(position);
+
+    //console.log('====== peek-file definition lookup ===========');
+    console.log('word: ' + word);
+    console.log('line: ' + line.text);
+
+    // We are looking for strings with filenames
+    // - simple hack for now we look for the string with our current word in it on our line
+    //   and where our cursor position is inside the string
+    let re_str = `^<@?\\w*\\s+(.*?${word}.*?)\\s*$`
+    let match = line.text.match(re_str);
+
+    this.log_debug('re_str: ', re_str);
+    this.log_debug("   Match: ", match);
+
+    if (match){
+      let potential_fname = match[1] || match[2];
+      let match_index:number  = match.index || 0;
+      let match_start:number = match_index;
+      let match_end:number = match_index + potential_fname.length;
+
+      // Verify the match string is at same location as cursor
+      if((position.character >= match_start) &&
+          (position.character <= match_end))
+      {
+          let full_path   = path.resolve(working_dir, potential_fname);
+          this.log_debug(" Match: ", match);
+          this.log_debug(" Fname: ", potential_fname);
+          this.log_debug("  Full: ", full_path);
+
+          // Find all potential paths to check and return the first one found
+          let potential_fnames = this.getPotentialPaths(full_path);
+          this.log_debug(" potential fnames: ", potential_fnames);
+
+          let found_fname = potential_fnames.find((fname_full) => {
+            this.log_debug(" checking: ", fname_full);
+            return fs.existsSync(fname_full);
+          });
+          if (found_fname != null) {
+            this.log_debug('found: ', found_fname);
+            return new vscode.Location(vscode.Uri.file(found_fname), new vscode.Position(0, 1));
+          }
+      }
+    }
+
+    return null;
+  }
+
+  private log_debug(message:string, obj:any):void{
+    console.log(message, obj);
+  }
+
+  getPotentialPaths(lookupPath: string): string[] {
+    let potential_paths: string[] = [lookupPath];
+
+    // Add on list where we just add the file extension directly
+    this.fileSearchExtensions.forEach((extStr) => {
+       potential_paths.push(lookupPath + extStr);
+    });
+
+    // if we have an extension, then try replacing it.
+    let parsed_path = path.parse(lookupPath);
+    if (parsed_path.ext !== "") {
+       this.fileSearchExtensions.forEach((extStr) => {
+          const new_path = path.format({
+             base: parsed_path.name + extStr,
+             dir: parsed_path.dir,
+             ext: extStr,
+             name: parsed_path.name,
+             root: parsed_path.root
+          });
+          potential_paths.push(new_path);
+       });
+    }
+
+    return potential_paths;
+ }
+
+
+}

--- a/src/provider/httpDefinitionProvider.ts
+++ b/src/provider/httpDefinitionProvider.ts
@@ -4,74 +4,58 @@ import { DocumentStore } from '../documentStore';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import * as httpyac from 'httpyac';
+
 // thanks to https://github.com/abierbaum/vscode-file-peek
 
 export class HttpDefinitionProvider implements vscode.DefinitionProvider {
-  private isDebug: boolean;
+
   protected fileSearchExtensions: string[] = ['json'];
 
   constructor(readonly documentStore: DocumentStore) {
-    this.isDebug = false;
   }
 
-  provideDefinition(
+  public async provideDefinition(
     document: vscode.TextDocument,
     position: vscode.Position
-  ): vscode.ProviderResult<vscode.Definition | vscode.LocationLink[]> {
-    const working_dir = path.dirname(document.fileName);
+  ): Promise<vscode.Definition | vscode.LocationLink[]> {
+    const result: Array<vscode.Location> = [];
+    const httpFile = await this.documentStore.getHttpFile(document);
+    const workingDir = path.dirname(document.fileName);
     const word = document.getText(document.getWordRangeAtPosition(position));
     const line = document.lineAt(position);
 
-    this.log_debug('====== peek-file definition lookup ===========', '');
-    this.log_debug('word: ', word);
-    this.log_debug('line: ', line.text);
 
-    // We are looking for strings with filenames
-    // - simple hack for now we look for the string with our current word in it on our line
-    //   and where our cursor position is inside the string
-    const re_str = `^<@?\\w*\\s+(.*?${word}.*?)\\s*$`;
-    const match = line.text.match(re_str);
-
-    this.log_debug('re_str: ', re_str);
-    this.log_debug('   Match: ', match);
-
-    if (match) {
-      const potential_fname = match[1] || match[2];
-      const match_index: number = match.index || 0;
-      const match_start: number = match_index;
-      const match_end: number = match_index + potential_fname.length;
-
-      // Verify the match string is at same location as cursor
-      if (position.character >= match_start && position.character <= match_end) {
-        const full_path = path.resolve(working_dir, potential_fname);
-        this.log_debug(' Match: ', match);
-        this.log_debug(' Fname: ', potential_fname);
-        this.log_debug('  Full: ', full_path);
-
-        // Find all potential paths to check and return the first one found
-        const potential_fnames: string[] = this.getPotentialPaths(full_path);
-        this.log_debug(' potential fnames: ', potential_fnames);
-
-        const found_fname = potential_fnames.find(fname_full => {
-          this.log_debug(' checking: ', fname_full);
-          return fs.existsSync(fname_full);
-        });
-        if (found_fname !== null) {
-          const exact_found_fname: string = found_fname || '';
-          this.log_debug('found: ', exact_found_fname);
-          return new vscode.Location(vscode.Uri.file(exact_found_fname), new vscode.Position(0, 1));
+    if(httpFile){
+      for (const httpRegion of httpFile.httpRegions) {
+        const requestBody =
+          httpRegion.symbol.children?.find(obj => 
+            obj.kind === httpyac.HttpSymbolKind.requestBody && 
+            obj.startLine === line.lineNumber
+          );
+        if(requestBody){
+          const source = requestBody.source;
+          const reStr = `^<@?\\w*\\s+(.*?${word}.*?)\\s*$`;
+          const match = source?.match(reStr);
+          if (match) {
+            const potentialFname = match[1] || match[2];
+            console.log("potentialFname", potentialFname)
+            const fullPath = path.resolve(workingDir, potentialFname);
+            const potentialFnames: string[] = this.getPotentialPaths(fullPath);
+            const foundFname = potentialFnames.find(fnameFull => fs.existsSync(fnameFull)) || "";
+            result.push(
+              new vscode.Location(vscode.Uri.file(foundFname), new vscode.Position(0, 1))
+            );
+          }
+          break;
         }
       }
     }
 
-    return null;
+    return Promise.resolve(result);
   }
 
-  private log_debug(message: string, obj: string[] | string | number | RegExpExecArray | null): void {
-    if (this.isDebug) {
-      console.debug(message, obj);
-    }
-  }
+
 
   getPotentialPaths(lookupPath: string): string[] {
     const potential_paths: string[] = [lookupPath];

--- a/src/provider/httpDefinitionProvider.ts
+++ b/src/provider/httpDefinitionProvider.ts
@@ -1,102 +1,101 @@
-
-import * as vscode from 'vscode'
+import * as vscode from 'vscode';
 import { DocumentStore } from '../documentStore';
 
-import * as fs   from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 
 // thanks to https://github.com/abierbaum/vscode-file-peek
 
 export class HttpDefinitionProvider implements vscode.DefinitionProvider {
-
+  private isDebug: boolean;
   protected fileSearchExtensions: string[] = ['json'];
 
-  constructor(readonly documentStore: DocumentStore){
-    
+  constructor(readonly documentStore: DocumentStore) {
+    this.isDebug = false;
   }
 
-  provideDefinition(document: vscode.TextDocument, 
-                    position: vscode.Position, 
-                    token: vscode.CancellationToken): vscode.ProviderResult<vscode.Definition | vscode.LocationLink[]> {
-    let working_dir = path.dirname(document.fileName);
-    let word        = document.getText(document.getWordRangeAtPosition(position));
-    let line        = document.lineAt(position);
+  provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.ProviderResult<vscode.Definition | vscode.LocationLink[]> {
+    const working_dir = path.dirname(document.fileName);
+    const word = document.getText(document.getWordRangeAtPosition(position));
+    const line = document.lineAt(position);
 
-    //console.log('====== peek-file definition lookup ===========');
-    console.log('word: ' + word);
-    console.log('line: ' + line.text);
+    this.log_debug('====== peek-file definition lookup ===========', '');
+    this.log_debug('word: ', word);
+    this.log_debug('line: ', line.text);
 
     // We are looking for strings with filenames
     // - simple hack for now we look for the string with our current word in it on our line
     //   and where our cursor position is inside the string
-    let re_str = `^<@?\\w*\\s+(.*?${word}.*?)\\s*$`
-    let match = line.text.match(re_str);
+    const re_str = `^<@?\\w*\\s+(.*?${word}.*?)\\s*$`;
+    const match = line.text.match(re_str);
 
     this.log_debug('re_str: ', re_str);
-    this.log_debug("   Match: ", match);
+    this.log_debug('   Match: ', match);
 
-    if (match){
-      let potential_fname = match[1] || match[2];
-      let match_index:number  = match.index || 0;
-      let match_start:number = match_index;
-      let match_end:number = match_index + potential_fname.length;
+    if (match) {
+      const potential_fname = match[1] || match[2];
+      const match_index: number = match.index || 0;
+      const match_start: number = match_index;
+      const match_end: number = match_index + potential_fname.length;
 
       // Verify the match string is at same location as cursor
-      if((position.character >= match_start) &&
-          (position.character <= match_end))
-      {
-          let full_path   = path.resolve(working_dir, potential_fname);
-          this.log_debug(" Match: ", match);
-          this.log_debug(" Fname: ", potential_fname);
-          this.log_debug("  Full: ", full_path);
+      if (position.character >= match_start && position.character <= match_end) {
+        const full_path = path.resolve(working_dir, potential_fname);
+        this.log_debug(' Match: ', match);
+        this.log_debug(' Fname: ', potential_fname);
+        this.log_debug('  Full: ', full_path);
 
-          // Find all potential paths to check and return the first one found
-          let potential_fnames = this.getPotentialPaths(full_path);
-          this.log_debug(" potential fnames: ", potential_fnames);
+        // Find all potential paths to check and return the first one found
+        const potential_fnames: string[] = this.getPotentialPaths(full_path);
+        this.log_debug(' potential fnames: ', potential_fnames);
 
-          let found_fname = potential_fnames.find((fname_full) => {
-            this.log_debug(" checking: ", fname_full);
-            return fs.existsSync(fname_full);
-          });
-          if (found_fname != null) {
-            this.log_debug('found: ', found_fname);
-            return new vscode.Location(vscode.Uri.file(found_fname), new vscode.Position(0, 1));
-          }
+        const found_fname = potential_fnames.find(fname_full => {
+          this.log_debug(' checking: ', fname_full);
+          return fs.existsSync(fname_full);
+        });
+        if (found_fname !== null) {
+          const exact_found_fname: string = found_fname || '';
+          this.log_debug('found: ', exact_found_fname);
+          return new vscode.Location(vscode.Uri.file(exact_found_fname), new vscode.Position(0, 1));
+        }
       }
     }
 
     return null;
   }
 
-  private log_debug(message:string, obj:any):void{
-    console.log(message, obj);
+  private log_debug(message: string, obj: string[] | string | number | RegExpExecArray | null): void {
+    if (this.isDebug) {
+      console.debug(message, obj);
+    }
   }
 
   getPotentialPaths(lookupPath: string): string[] {
-    let potential_paths: string[] = [lookupPath];
+    const potential_paths: string[] = [lookupPath];
 
     // Add on list where we just add the file extension directly
-    this.fileSearchExtensions.forEach((extStr) => {
-       potential_paths.push(lookupPath + extStr);
+    this.fileSearchExtensions.forEach(extStr => {
+      potential_paths.push(lookupPath + extStr);
     });
 
     // if we have an extension, then try replacing it.
-    let parsed_path = path.parse(lookupPath);
-    if (parsed_path.ext !== "") {
-       this.fileSearchExtensions.forEach((extStr) => {
-          const new_path = path.format({
-             base: parsed_path.name + extStr,
-             dir: parsed_path.dir,
-             ext: extStr,
-             name: parsed_path.name,
-             root: parsed_path.root
-          });
-          potential_paths.push(new_path);
-       });
+    const parsed_path = path.parse(lookupPath);
+    if (parsed_path.ext !== '') {
+      this.fileSearchExtensions.forEach(extStr => {
+        const new_path = path.format({
+          base: parsed_path.name + extStr,
+          dir: parsed_path.dir,
+          ext: extStr,
+          name: parsed_path.name,
+          root: parsed_path.root,
+        });
+        potential_paths.push(new_path);
+      });
     }
 
     return potential_paths;
- }
-
-
+  }
 }

--- a/src/provider/httpDefinitionProvider.ts
+++ b/src/provider/httpDefinitionProvider.ts
@@ -1,17 +1,12 @@
 import * as vscode from 'vscode';
+import * as httpyac from 'httpyac';
 import { DocumentStore } from '../documentStore';
 
-import * as fs from 'fs';
 import * as path from 'path';
 
-import * as httpyac from 'httpyac';
 
-// thanks to https://github.com/abierbaum/vscode-file-peek
 
 export class HttpDefinitionProvider implements vscode.DefinitionProvider {
-
-  protected fileSearchExtensions: string[] = ['json'];
-
   constructor(readonly documentStore: DocumentStore) {
   }
 
@@ -19,67 +14,40 @@ export class HttpDefinitionProvider implements vscode.DefinitionProvider {
     document: vscode.TextDocument,
     position: vscode.Position
   ): Promise<vscode.Definition | vscode.LocationLink[]> {
+
     const result: Array<vscode.Location> = [];
     const httpFile = await this.documentStore.getHttpFile(document);
     const workingDir = path.dirname(document.fileName);
     const word = document.getText(document.getWordRangeAtPosition(position));
     const line = document.lineAt(position);
 
-
     if(httpFile){
       for (const httpRegion of httpFile.httpRegions) {
+        // find if current position is with in requestBody
         const requestBody =
           httpRegion.symbol.children?.find(obj => 
+            // this could be with new new SymbolKind.File 
             obj.kind === httpyac.HttpSymbolKind.requestBody && 
             obj.startLine === line.lineNumber
           );
         if(requestBody){
+          // check if request body is link to file
           const source = requestBody.source;
           const reStr = `^<@?\\w*\\s+(.*?${word}.*?)\\s*$`;
           const match = source?.match(reStr);
           if (match) {
             const potentialFname = match[1] || match[2];
-            console.log("potentialFname", potentialFname)
+            // resolve from relative path to absolute
             const fullPath = path.resolve(workingDir, potentialFname);
-            const potentialFnames: string[] = this.getPotentialPaths(fullPath);
-            const foundFname = potentialFnames.find(fnameFull => fs.existsSync(fnameFull)) || "";
             result.push(
-              new vscode.Location(vscode.Uri.file(foundFname), new vscode.Position(0, 1))
+              new vscode.Location(vscode.Uri.file(fullPath), new vscode.Position(0, 1))
             );
           }
           break;
         }
       }
     }
-
     return Promise.resolve(result);
   }
 
-
-
-  getPotentialPaths(lookupPath: string): string[] {
-    const potential_paths: string[] = [lookupPath];
-
-    // Add on list where we just add the file extension directly
-    this.fileSearchExtensions.forEach(extStr => {
-      potential_paths.push(lookupPath + extStr);
-    });
-
-    // if we have an extension, then try replacing it.
-    const parsed_path = path.parse(lookupPath);
-    if (parsed_path.ext !== '') {
-      this.fileSearchExtensions.forEach(extStr => {
-        const new_path = path.format({
-          base: parsed_path.name + extStr,
-          dir: parsed_path.dir,
-          ext: extStr,
-          name: parsed_path.name,
-          root: parsed_path.root,
-        });
-        potential_paths.push(new_path);
-      });
-    }
-
-    return potential_paths;
-  }
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -13,4 +13,5 @@ export * from './storeController';
 export * from './variablesHoverProvider';
 export * from './variablesTreeDataProvider';
 export * from './userSessionTreeDataProvider';
+export * from './httpDefinitionProvider';
 export * from './test';


### PR DESCRIPTION
Request add navigation for request body files.

Idea is that if I have many request files it would be nice to jump over when ever I need for review or editing.  It would like this:

![test_httpyac-1703946442023](https://github.com/AnWeber/vscode-httpyac/assets/1858749/83282bd0-ff34-42a7-9bae-4c6e6b52dfda)

Currently it works with json extension files as I am using them most, but this filtering list might externalized to configuration in a future.

My code is based on https://github.com/abierbaum/vscode-file-peek